### PR TITLE
Add helper function to read ISC from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Adding zone. Input is in json string. Returns ISC dictionary with added zone. Th
 WriteToFile(isc_dict, isc_specialkeys, filename)
 ```
 Write ISC dictionary to a file
+
+```
+ReadFromFile(filename)
+```
+Read an ISC file into a dictionary

--- a/iscpy/iscpy_core/core.py
+++ b/iscpy/iscpy_core/core.py
@@ -335,3 +335,7 @@ def WriteToFile(isc_dict, isc_specialkeys, filename):
         conts = ContentToWrite(isc_dict, 0, [], isc_specialkeys)
         for c in conts:
             f.write(c)
+
+def ReadFromFile(filename):
+    with open(filename) as f:
+        return ParseISCString(f.read())


### PR DESCRIPTION
I have been looking around for a simple library to parse `/etc/named.conf` so I could extract some info about it, adding this helper function and the README to me made it clear that this library can do that pretty easily.